### PR TITLE
Add type to payment button

### DIFF
--- a/src/PayStack.js
+++ b/src/PayStack.js
@@ -63,7 +63,12 @@ class PayStack extends Component {
 			:
 			(
 				<span>
-          <button className={this.state.class} onClick={this.payWithPaystack} disabled={this.state.disabled}>
+          <button
+						type="button"
+						className={this.state.class}
+						onClick={this.payWithPaystack}
+						disabled={this.state.disabled}
+					>
             {this.state.text}
           </button>
         </span>

--- a/src/PayStack.js
+++ b/src/PayStack.js
@@ -7,7 +7,7 @@ class PayStack extends Component {
 		super(props);
 		this.state = {
 			text: this.props.text || "Make Payment",
-			class: this.props.class || "",
+			class: this.props.class || this.props.className || "",
 			metadata: this.props.metadata || {},
 			currency: this.props.currency || "NGN",
 			plan: this.props.plan || "",


### PR DESCRIPTION
I added `type="button"` to the payment button. I had the button in a form and clicking it was causing the form to submit (and reload the page). I also noticed that the Paystack tutorial specifies setting the payment button's `type` to `button` for the inline implementation.

I also added a check for `this.state.class` to check for `this.props.className`. I tried to set the class prop but React was converting it to a prop named `className`, so it wasn't being set properly in the button.