### PR TITLE
Set reference property to optional

### DIFF
--- a/src/PayStack.js
+++ b/src/PayStack.js
@@ -116,7 +116,7 @@ PayStack.propTypes = {
   subaccount: PropTypes.string,
   transaction_charge: PropTypes.number,
   bearer: PropTypes.string,
-  reference: PropTypes.string.isRequired,
+  reference: PropTypes.string,
   email: PropTypes.string.isRequired,
   amount: PropTypes.number.isRequired, //in kobo
   paystackkey: PropTypes.string.isRequired,


### PR DESCRIPTION
Providing a unique transaction reference is not required, since Paystack autogenerates a transaction reference when there is none.