### PR TITLE
Correct metadata type signature as per docs

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -2,6 +2,15 @@ declare type Currency = 'NGN' | 'GHS' | 'USD' | 'ZAR';
 declare type PaymentChannels = 'bank' | 'card' | 'qr' | 'ussd' | 'mobile_money';
 declare type Bearer = 'account' | 'subaccount';
 declare type phone = number | string;
+interface PaystackMetadata {
+    custom_fields: PaystackCustomFields[]
+    [key: string]: any;
+  }
+interface PaystackCustomFields {
+    display_name: string
+    variable_name: string
+    value: any
+  }
 export interface PaystackProps {
     publicKey: string;
     email: string;
@@ -10,9 +19,7 @@ export interface PaystackProps {
     phone?: phone;
     amount: number;
     reference?: string;
-    metadata?: {
-        custom_field: Record<string, string>[];
-    };
+    metadata?: PaystackMetadata;
     currency?: Currency;
     channels?: PaymentChannels[];
     label?: string;


### PR DESCRIPTION
The docs for the popup are a bit misleading because they contain a typo calling `custom_fields` `custom_field` instead. You can see the correct way in the metadata documentation https://paystack.com/docs/payments/metadata/