### PR TITLE
Adding ability to pass parameters to Callback functions

### DIFF
--- a/libs/types.ts
+++ b/libs/types.ts
@@ -20,7 +20,7 @@ interface PaystackMetadata {
   [key: string]: any;
 }
 
-export type callback = () => void;
+export type callback = (error?: any, response?: any) => void;
 
 export interface PaystackProps {
   publicKey: string;


### PR DESCRIPTION
I ran into the issue upon updating to v4 and the PaystackButton component would not let me pass parameters to my callback function for running onSuccess or onCancel. I am guessing this is due to the upgrade to TypeScript, but it should allow for functionality of passing parameters to these functions for more flexibility.