### PR TITLE
Update types.d.ts 

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -8,9 +8,6 @@ interface PaystackCustomFields {
     value: any;
 }
 interface PaystackMetadata {
-    custom_fields: PaystackCustomFields[];
-}
-interface PaystackMetadata {
     [key: string]: any;
 }
 export declare type callback = () => void;


### PR DESCRIPTION
- Remove the initial typing declared for Paystack Metadata. It still affects Typescript users.