### PR TITLE
Allows props passing(reference) to callback in TS

### DIFF
--- a/libs/types.ts
+++ b/libs/types.ts
@@ -20,7 +20,7 @@ interface PaystackMetadata {
   [key: string]: any;
 }
 
-export type callback = () => void;
+export type callback = (ref?: string) => void;
 
 export interface PaystackProps {
   publicKey: string;


### PR DESCRIPTION
#62 
Updated Callback type to allow `reference`  to be passed to `OnSuccess` in typescript

@iamraphson 