### PR TITLE
update usePaystackPayment return type to allow for parameters

### DIFF
--- a/libs/use-paystack.ts
+++ b/libs/use-paystack.ts
@@ -5,7 +5,7 @@ import {callPaystackPop} from './paystack-actions';
 
 export default function usePaystackPayment(
   options: PaystackProps,
-): (callback?: () => void, onClose?: () => void) => void {
+): (callback?: callback, onClose?: callback) => void {
   const [scriptLoaded, scriptError] = usePaystackScript();
   const {
     publicKey,


### PR DESCRIPTION
`usePaystackPayment` to use the updated `callback` type to allow for passing parameters 