### PR TITLE
fix:add argument for type callback

### DIFF
--- a/dist/types.d.ts
+++ b/dist/types.d.ts
@@ -13,7 +13,7 @@ interface PaystackMetadata {
 interface PaystackMetadata {
     [key: string]: any;
 }
-export declare type callback = () => void;
+export declare type callback = (response:{reference:""}) => void;
 export interface PaystackProps {
     publicKey: string;
     email: string;


### PR DESCRIPTION
Added an argument, response object, to the type, callback to enable typescript users to get the object from the onSuccess property