### PR TITLE
Fix: Use callback declaration from types

### DIFF
--- a/dist/paystack-consumer.d.ts
+++ b/dist/paystack-consumer.d.ts
@@ -1,8 +1,8 @@
 import React from 'react';
-import { PaystackProps } from './types';
+import { PaystackProps, callback } from './types';
 interface PaystacConsumerProps extends PaystackProps {
     children: (arg: Record<string, any>) => any;
-    onSuccess?: () => void;
+    onSuccess?: callback;
     onClose?: () => void;
 }
 declare const PaystackConsumer: React.ForwardRefExoticComponent<PaystacConsumerProps & React.RefAttributes<unknown>>;

--- a/dist/paystack-context.d.ts
+++ b/dist/paystack-context.d.ts
@@ -2,7 +2,7 @@
 import { callback } from './types';
 type IPaystackContext = {
     initializePayment: (arg0: callback, arg1: callback) => void;
-    onSuccess: () => void;
+    onSuccess: callback;
     onClose: () => void;
 };
 declare const PaystackContext: import("react").Context<IPaystackContext>;


### PR DESCRIPTION
`PaystackConsumer` and `PaystackContext` are using `() =>void`  for `onSuccess` instead of `callback` from types