### PR TITLE
adding Explanation on how to pass in metadata in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,25 @@ import './App.css';
   export default App;
 ```
 
+### Sending Metadata with Transaction
+If you want to send extra metadata e.g. Transaction description, user that made the transaction. Edit your config like so:
+
+```ts
+    const config = {
+       // Your required fields
+          metadata: {
+            custom_fields: [
+                {
+                    display_name: 'description',
+                    variable_name: 'description',
+                    value: 'Funding Wallet'
+                }
+                // To pass extra metadata, add an object with the same fields as above
+            ]
+        }
+    };
+```
+
 Please checkout [Paystack Documentation](https://developers.paystack.co/docs/paystack-inline) for other available options you can add to the tag
 
 ## Deployment


### PR DESCRIPTION
Thanks for your awesome package! I wanted to pass in some metadata with a successful transaction earlier today. Then I noticed there was no explanation on the docs. I was about to write a custom wrapper till I read through the code and found that your wrapper actually takes in those paramaters.

This fix to the docs is for future users who may want to know how they could quickly set it up